### PR TITLE
fix(ConvModelV2): move `BatchNorm` before the `gelu` activation function

### DIFF
--- a/src/dlfb/dna/model.py
+++ b/src/dlfb/dna/model.py
@@ -79,8 +79,8 @@ class ConvModelV2(nn.Module):
     x = nn.Conv(
       features=self.conv_filters, kernel_size=self.kernel_size, padding="SAME"
     )(x)
-    x = nn.gelu(x)
     x = nn.BatchNorm(use_running_average=not is_training)(x)
+    x = nn.gelu(x)
     x = nn.max_pool(x, window_shape=(2,), strides=(2,))
 
     # Flatten the values before passing them to the dense layers.


### PR DESCRIPTION
It follows [this question](https://github.com/orgs/deep-learning-for-biology/discussions/10) and fix CNN by moving `BatchNorm` before the `gelu` activation function