### PR TITLE
override assets dir for running outside collab

### DIFF
--- a/src/dlfb/utils/context.py
+++ b/src/dlfb/utils/context.py
@@ -10,6 +10,9 @@ def assets(subdir: str | None = None) -> str:
 
 
 def ensure_context() -> None:
+  if "ASSETS_DIR" in os.environ:
+      return
+
   context = detect_context()
   assets_dir = {
     "local": "/content/drive/MyDrive/dlfb/assets",


### PR DESCRIPTION
The notebooks throw an error when run outside of collab because of hardcoded paths. This fix allows us to set the env var ASSET_PATH to point to a local dir containing the downloaded assets.

To then run the notebooks outside of Collab:

1. Export environment variable ASSET_VARS to a local folder (e.g in .env file in VS Code)

2. Modify the cell with the  dlfb-provision command to download the assets to that dir

e.g cell 3 on chapter_3_dna:
```
!dlfb-provision --chapter dna --destination $ASSETS_DIR
```

